### PR TITLE
Upgrade to bootstrap 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mdx-js/mdx": "^1.6.1",
     "@mdx-js/react": "^1.6.1",
     "algoliasearch": "^4.2.0",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "4.5",
     "gatsby": "^2.21.12",
     "gatsby-background-image": "^0.9.19",
     "gatsby-image": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,7 +2936,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.4.1:
+bootstrap@4.5:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
   integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==


### PR DESCRIPTION
shamelessly stolen from https://github.com/rocketinsights/edb-marketing-nextjs/pull/139/files