### PR TITLE
Add min width to MainContent so flexbox can shrink the container

### DIFF
--- a/src/components/main-content.js
+++ b/src/components/main-content.js
@@ -3,7 +3,7 @@ import SearchNavigation from './search-navigation';
 
 const MainContent = ({ children }) => {
   return (
-    <div className="flex-grow-1 border-right">
+    <div className="flex-grow-1 border-right min-w-50">
       <SearchNavigation />
       <main role="main" className="mt-0 p-5">
         {children}


### PR DESCRIPTION
See title. Flexbox quirk. I just used an existing class EDB defined, since the `min-width` value doesn't matter.

![Screen Shot 2020-05-26 at 4 39 46 PM](https://user-images.githubusercontent.com/2780987/82948465-d3186900-9f6f-11ea-8572-7a5aff4310dd.png)


