### PR TITLE
Learn index

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,11 +39,6 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: 'version',
       value: version,
     });
-    createNodeField({
-      node,
-      name: 'topic',
-      value: null,
-    });
   }
   if (
     node.internal.type === 'Mdx' &&

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -83,6 +83,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         nodes {
           frontmatter {
             title
+            description
           }
           fields {
             path

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,6 +39,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: 'version',
       value: version,
     });
+    createNodeField({
+      node,
+      name: 'topic',
+      value: null,
+    });
   }
   if (
     node.internal.type === 'Mdx' &&

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -31,6 +31,52 @@ const ContentRow = ({ children }) => (
   </div>
 );
 
+const getChildren = (path, navLinks) => {
+  return navLinks.filter(
+    node =>
+      node.fields.path.includes(path) &&
+      node.fields.path.split('/').length === path.split('/').length + 1,
+  );
+};
+
+const Tiles = ({ mdx, navLinks }) => {
+  const { path } = mdx.fields;
+  const depth = path.split('/').length;
+  if (depth === 3) {
+    const tiles = getChildren(path, navLinks).map(child => {
+      let newChild = { ...child };
+      const { path } = newChild.fields;
+      newChild['children'] = getChildren(path, navLinks);
+      return newChild;
+    });
+    return (
+      <>
+        {tiles.map(tile => {
+          return (
+            <>
+              <div>{tile.frontmatter.title}</div>
+              {tile.children.map(child => (
+                <div>{child.frontmatter.title}</div>
+              ))}
+            </>
+          );
+        })}
+      </>
+    );
+  }
+  if (depth === 4) {
+    const tiles = getChildren(path, navLinks);
+    return (
+      <>
+        {tiles.map(tile => (
+          <div>{tile.frontmatter.title}</div>
+        ))}
+      </>
+    );
+  }
+  return <div>hi</div>;
+};
+
 const LearnDocTemplate = ({ data, pageContext }) => {
   const { mdx } = data;
   const { navLinks } = pageContext;
@@ -51,6 +97,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
           <ContentRow>
             <Col md={9}>
               <MDXRenderer>{mdx.body}</MDXRenderer>
+              <Tiles mdx={mdx} navLinks={navLinks} />
             </Col>
 
             <Col md={3}>

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -15,6 +15,7 @@ export const query = graphql`
     mdx(fields: { path: { eq: $path } }) {
       frontmatter {
         title
+        description
       }
       fields {
         path
@@ -49,14 +50,19 @@ const Tiles = ({ mdx, navLinks }) => {
       newChild['children'] = getChildren(path, navLinks);
       return newChild;
     });
+    console.log(tiles);
+
     return (
       <>
         {tiles.map(tile => {
           return (
             <>
               <div>{tile.frontmatter.title}</div>
+              <div>{tile.frontmatter.description}</div>
               {tile.children.map(child => (
-                <div>{child.frontmatter.title}</div>
+                <>
+                  <div>{child.frontmatter.title}</div>
+                </>
               ))}
             </>
           );
@@ -66,10 +72,14 @@ const Tiles = ({ mdx, navLinks }) => {
   }
   if (depth === 4) {
     const tiles = getChildren(path, navLinks);
+    console.log(tiles);
     return (
       <>
         {tiles.map(tile => (
-          <div>{tile.frontmatter.title}</div>
+          <>
+            <div>{tile.frontmatter.title}</div>
+            <div>{tile.frontmatter.description}</div>
+          </>
         ))}
       </>
     );

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -72,7 +72,6 @@ const Tiles = ({ mdx, navLinks }) => {
   }
   if (depth === 4) {
     const tiles = getChildren(path, navLinks);
-    console.log(tiles);
     return (
       <>
         {tiles.map(tile => (

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -15,7 +15,6 @@ export const query = graphql`
     mdx(fields: { path: { eq: $path } }) {
       frontmatter {
         title
-        description
       }
       fields {
         path


### PR DESCRIPTION
This adds to the template for the advocacy docs index pages to include the information about the children of each index page in the page content. This is a bare bones version to be styled by Evan. There is one style for the index for the whole section and another for each topic within that section.