### PR TITLE
make mobile view look like desktop

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -14,7 +14,7 @@ const Layout = ({ children }) => {
         <html lang="en" />
         <title>{title}</title>
         <meta name="description" content={description} />
-        <body className="bg-light" />
+        <body className="bg-light fixed-container" />
       </Helmet>
       <MDXProvider
         components={{

--- a/src/components/side-navigation.js
+++ b/src/components/side-navigation.js
@@ -30,8 +30,8 @@ const SideNavigationFooter = () => (
 
 const SideNavigation = ({ children }) => {
   return (
-    <nav className="sidebar d-none d-md-block bg-light border-right">
-      <div className="sidebar-sticky pl-0 pr-4 pb-4">
+    <nav className="sidebar d-block bg-light border-right">
+      <div className="sidebar-sticky ml-1 pl-0 pr-4 pb-4">
         <LogoLink />
         {children}
         <SideNavigationFooter />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,7 +32,7 @@ export default data => {
   return (
     <Layout>
       <TopBar />
-      <Container className="p-0 d-flex bg-white">
+      <Container className="p-0 d-flex bg-white fixed-container">
         <SideNavigation>
           <IndexLinks indexLinkList={advocacyLinks.concat(indexLinkList)} />
         </SideNavigation>

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -10,3 +10,7 @@
 .overflow-scroll {
   overflow: scroll;
 }
+
+.fixed-container {
+  min-width: 1140px;
+}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -70,7 +70,7 @@ const DocTemplate = ({ data, pageContext }) => {
   return (
     <Layout>
       <TopBar />
-      <Container className="p-0 d-flex bg-white">
+      <Container className="p-0 d-flex bg-white fixed-container">
         <SideNavigation>
           <LeftNav
             navLinks={navLinks}
@@ -83,11 +83,11 @@ const DocTemplate = ({ data, pageContext }) => {
           <h1 className="balance-text">{mdx.frontmatter.title}</h1>
 
           <ContentRow>
-            <Col md={9}>
+            <Col xs={9}>
               <MDXRenderer>{mdx.body}</MDXRenderer>
             </Col>
 
-            <Col md={3}>
+            <Col xs={3}>
               {mdx.tableOfContents.items && (
                 <TableOfContents toc={mdx.tableOfContents.items} />
               )}

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -67,7 +67,7 @@ const LearnDocTemplate = ({ data, pageContext }) => {
   return (
     <Layout>
       <TopBar />
-      <Container className="p-0 d-flex bg-white">
+      <Container className="p-0 d-flex bg-white fixed-container">
         <SideNavigation>
           <LeftNav navLinks={navLinks} path={mdx.fields.path} />
         </SideNavigation>
@@ -79,12 +79,12 @@ const LearnDocTemplate = ({ data, pageContext }) => {
 
           {mdx.tableOfContents.item ? (
             <ContentRow>
-              <Col md={9}>
+              <Col xs={9}>
                 <MDXRenderer>{mdx.body}</MDXRenderer>
                 <Tiles mdx={mdx} navLinks={navLinks} />
               </Col>
 
-              <Col md={3}>
+              <Col xs={3}>
                 {mdx.tableOfContents.items && (
                   <TableOfContents toc={mdx.tableOfContents.items} />
                 )}


### PR DESCRIPTION
Fixed the container width to the bootstrap default container size. Ran this by Matt, he's happy with it

![Screen Shot 2020-06-03 at 4 59 46 PM](https://user-images.githubusercontent.com/2780987/83688820-f9678580-a5bb-11ea-805d-f669daee0a1b.png)
