### PR TITLE
Add context-relevant template links to advocacy pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -198,9 +198,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const navLinks = learn.filter(
       node => node.fields.topic === doc.fields.topic,
     );
-    const githubLink =
-      'https://github.com/rocketinsights/edb_docs_advocacy/edit/master/advocacy_docs' +
+    const advocacyDocsRepoUrl = 'https://github.com/rocketinsights/edb_docs_advocacy';
+    const githubLink = advocacyDocsRepoUrl + 
+      '/edit/master/advocacy_docs' +
       doc.fields.path +
+      (doc.fileAbsolutePath.includes('index.mdx') ? '/index.mdx' : '.mdx');
+    const githubIssuesLink = advocacyDocsRepoUrl + 
+      '/issues/new?title=Regarding%20' +
+      encodeURIComponent(doc.fields.path) +
       (doc.fileAbsolutePath.includes('index.mdx') ? '/index.mdx' : '.mdx');
     actions.createPage({
       path: doc.fields.path,
@@ -208,6 +213,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       context: {
         navLinks: navLinks,
         githubLink: githubLink,
+        githubIssuesLink: githubIssuesLink,
       },
     });
   });

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -78,7 +78,7 @@ const Tiles = ({ mdx, navLinks }) => {
 
 const LearnDocTemplate = ({ data, pageContext }) => {
   const { mdx } = data;
-  const { navLinks, githubLink } = pageContext;
+  const { navLinks, githubLink, githubIssuesLink } = pageContext;
   const pageMeta = {
     title: mdx.frontmatter.title,
     description: mdx.frontmatter.description,
@@ -128,6 +128,14 @@ const LearnDocTemplate = ({ data, pageContext }) => {
           )}
 
           <DevFrontmatter frontmatter={mdx.frontmatter} />
+
+          <p>
+            Could this page could be better? <a href={githubIssuesLink + "&template=problem-with-topic.md&labels=bug"}>
+              Report a problem
+            </a> or <a href={githubIssuesLink + "&template=suggest-addition-to-topic.md&labels=enhancement"}>
+              suggest an addition
+            </a>!
+          </p>
 
           <Footer />
         </MainContent>


### PR DESCRIPTION
The goal here is to make it simple for folks to report issues (or suggest changes) on specific pages by providing links to issue templates at the bottom of the page:

![Know of a way this page could be better? Report a problem or suggest an addition!](https://user-images.githubusercontent.com/63653723/90810898-f2a9fe00-e2e0-11ea-9691-7fc8eff316e1.png)

Those two links contain the path (not URL) of the page being viewed prepopulated as the title, along with references to the specific template ([problem](https://github.com/rocketinsights/edb_docs_advocacy/issues/new?title=Regarding%20%2Fbuilding%2Fsql%2Fviews.mdx&template=problem-with-topic.md&labels=bug) or [addition](https://github.com/rocketinsights/edb_docs_advocacy/issues/new?title=Regarding%20%2Fbuilding%2Fsql%2Fviews.mdx&template=suggest-addition-to-topic.md&labels=enhancement) with which to pre-fill the body of the report.

Moved here from https://github.com/rocketinsights/edb_docs_advocacy/pull/73