### PR TITLE
Katacoda reconciliation

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -4,6 +4,7 @@ import useSiteMetadata from '../hooks/use-sitemetadata';
 import TextBalancer from '../components/text-balancer';
 import { MDXProvider } from '@mdx-js/react';
 import Icon from '../components/icon/';
+import Katacoda from '../advocacy_components/katacoda';
 
 import '../styles/index.scss';
 
@@ -41,6 +42,7 @@ const Layout = ({ children, pageMeta, background = 'light' }) => {
           h2: props => <h2 {...props} className='mt-5' />, // eslint-disable-line jsx-a11y/heading-has-content
           h3: props => <h3 {...props} className='mt-4-5' />, // eslint-disable-line jsx-a11y/heading-has-content
           Icon,
+          Katacoda,
         }}
       >
         {children}

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -40,6 +40,26 @@ main {
   box-shadow: 0px 0px 1px 1px $gray-100;
 }
 
+// Katacoda in panel display mode adds a fixed-position console with this height
+.katacoda-panel-active body
+{
+  margin-bottom: 40vh;
+}
+
+// Katacoda-enabled code blocks will have this class in panel display mode
+pre.katacoda-exec
+{
+  cursor: pointer;
+}
+
+// Because it is fixed position, the Katacoda panel screws up printing big-time
+@media print {
+  .katacoda-panel-active {
+    body { margin-bottom: unset; }
+    .katacoda-embed { display: none; }
+  }
+}
+
 .font-weight-400 {
   font-weight: 400;
 }


### PR DESCRIPTION
Two Katacoda-related changes here:

- Bring in styles from this PR: https://github.com/rocketinsights/edb_docs_advocacy/pull/79
  (I assume CSS needs to be consistent between repos)

- Add Katacoda to components list, so that it is available without an explicit import. Goal here is to avoid requiring folks to remember to import it in advocacy docs, since the relative path changes depending on where you're at in the hierarchy and seems error-prone. If there's an easier / better way to do this, lemme know.